### PR TITLE
Bumps node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-    "name": "fruster-template-service",
-    "version": "0.0.1",
-    "private": true,
-    "scripts": {
-        "start": "node ./app.js",
-        "test": "nyc --reporter=html --check-coverage --lines 90 node ./spec/support/jasmine-runner.js"
-    },
-    "dependencies": {
-        "fruster-bus": "^0.2.24",
-        "fruster-errors": "0.1.1",
-        "fruster-health": "^0.0.12",
-        "fruster-log": "^0.0.18",
-        "mongodb": "^2.2.34"
-    },
-    "devDependencies": {
-        "fruster-test-utils": "^0.3.21",
-        "jasmine": "^3.0.0",
-        "jasmine-spec-reporter": "^4.2.1",
-        "nyc": "^11.4.1"
-    },
-    "engines": {
-        "node": "7.9.0"
-    },
-    "nyc": {
-        "exclude": [
-            "spec/*",
-            "lib/errors.js",
-            "lib/constants.js",
-            "lib/docs.js",
-            "config.js"
-        ]
-    }
+	"name": "fruster-template-service",
+	"version": "0.0.1",
+	"private": true,
+	"scripts": {
+		"start": "node ./app.js",
+		"test": "nyc --reporter=html --check-coverage --lines 90 node ./spec/support/jasmine-runner.js"
+	},
+	"dependencies": {
+		"fruster-bus": "^0.2.24",
+		"fruster-errors": "0.1.1",
+		"fruster-health": "^0.0.12",
+		"fruster-log": "^0.0.18",
+		"mongodb": "^2.2.34"
+	},
+	"devDependencies": {
+		"fruster-test-utils": "^0.3.21",
+		"jasmine": "^3.0.0",
+		"jasmine-spec-reporter": "^4.2.1",
+		"nyc": "^11.4.1"
+	},
+	"engines": {
+		"node": "8.1.2"
+	},
+	"nyc": {
+		"exclude": [
+			"spec/*",
+			"lib/errors.js",
+			"lib/constants.js",
+			"lib/docs.js",
+			"config.js"
+		]
+	}
 }


### PR DESCRIPTION
We should go with 8.x.x something. I just took 8.1.4, let me know if we need any specific version.
