### PR TITLE
[FIX] Removes afterEach(bus.clearClients);

### DIFF
--- a/spec/GetFooHandler.spec.js
+++ b/spec/GetFooHandler.spec.js
@@ -14,108 +14,106 @@ const FooModel = require('../lib/models/FooModel');
 
 describe("GetFooHandler", () => {
 
-    /** @type {FooModel} */
-    let foo;
+	/** @type {FooModel} */
+	let foo;
 
-    /** @type {Db} */
-    let db;
+	/** @type {Db} */
+	let db;
 
-    afterEach(bus.clearClients);
+	frusterTestUtils
+		.startBeforeEach(specConstants
+			.testUtilsOptions(async (connection) => {
+				MockBarService.init();
+				db = connection.db;
+				foo = await createFoo(db);
+			}));
 
-    frusterTestUtils
-        .startBeforeEach(specConstants
-            .testUtilsOptions(async (connection) => {
-                MockBarService.init();
-                db = connection.db;
-                foo = await createFoo(db);
-            }));
+	it("should return BAD_REQUEST if id is not a uuid", async done => {
+		try {
+			await bus.request({
+				subject: constants.endpoints.service.GET_FOO,
+				skipOptionsRequest: true,
+				message: {
+					user: fixtures.user,
+					reqId: "reqId",
+					data: { id: "fake" }
+				}
+			});
 
-    it("should return BAD_REQUEST if id is not a uuid", async done => {
-        try {
-            await bus.request({
-                subject: constants.endpoints.service.GET_FOO,
-                skipOptionsRequest: true,
-                message: {
-                    user: fixtures.user,
-                    reqId: "reqId",
-                    data: { id: "fake" }
-                }
-            });
+		} catch (err) {
+			expect(err.status).toBe(400);
+			expect(err.error.code).toBe(errors.badRequest().error.code);
 
-        } catch (err) {
-            expect(err.status).toBe(400);
-            expect(err.error.code).toBe(errors.badRequest().error.code);
+			done();
+		}
+	});
 
-            done();
-        }
-    });
+	it("should return NOT_FOUND if Foo does not exist", async done => {
+		try {
+			await bus.request({
+				subject: constants.endpoints.service.GET_FOO,
+				skipOptionsRequest: true,
+				message: {
+					user: fixtures.user,
+					reqId: "reqId",
+					data: { id: "26911e7d-bb4c-4a11-a93d-34240993bba2" }  // <- does not exist
+				}
+			});
+		} catch (err) {
+			expect(err.status).toBe(404);
+			expect(err.error.code).toBe(errors.notFound().error.code);
 
-    it("should return NOT_FOUND if Foo does not exist", async done => {
-        try {
-            await bus.request({
-                subject: constants.endpoints.service.GET_FOO,
-                skipOptionsRequest: true,
-                message: {
-                    user: fixtures.user,
-                    reqId: "reqId",
-                    data: { id: "26911e7d-bb4c-4a11-a93d-34240993bba2" }  // <- does not exist
-                }
-            });
-        } catch (err) {
-            expect(err.status).toBe(404);
-            expect(err.error.code).toBe(errors.notFound().error.code);
+			done();
+		}
+	});
 
-            done();
-        }
-    });
+	it("should return PERMISSION_DENIED if user has not permission to get foo", async done => {
+		try {
+			let user = fixtures.user;
+			user.scopes = [];
 
-    it("should return PERMISSION_DENIED if user has not permission to get foo", async done => {
-        try {
-            let user = fixtures.user;
-            user.scopes = [];
+			await bus.request({
+				subject: constants.endpoints.service.GET_FOO,
+				skipOptionsRequest: true,
+				message: {
+					user: user,
+					reqId: "reqId",
+					data: { id: foo.id }
+				}
+			});
+		} catch (err) {
+			expect(err.status).toBe(403);
+			expect(err.error.code).toBe("PERMISSION_DENIED");
 
-            await bus.request({
-                subject: constants.endpoints.service.GET_FOO,
-                skipOptionsRequest: true,
-                message: {
-                    user: user,
-                    reqId: "reqId",
-                    data: { id: foo.id }
-                }
-            });
-        } catch (err) {
-            expect(err.status).toBe(403);
-            expect(err.error.code).toBe("PERMISSION_DENIED");
+			done();
+		}
+	});
 
-            done();
-        }
-    });
+	it("should get Foo by its id", async done => {
+		try {
+			const resp = await bus.request({
+				subject: constants.endpoints.service.GET_FOO,
+				skipOptionsRequest: true,
+				message: {
+					user: fixtures.user,
+					reqId: "reqId",
+					data: { id: foo.id }
+				}
+			});
 
-    it("should get Foo by its id", async done => {
-        try {
-            const resp = await bus.request({
-                subject: constants.endpoints.service.GET_FOO,
-                skipOptionsRequest: true,
-                message: {
-                    user: fixtures.user,
-                    reqId: "reqId",
-                    data: { id: foo.id }
-                }
-            });
+			expect(resp.status).toBe(200);
+			done();
+		} catch (err) {
+			log.error(err);
+			done.fail(err);
+		}
+	});
 
-            expect(resp.status).toBe(200);
-            done();
-        } catch (err) {
-            log.error(err);
-            done.fail(err);
-        }
-    });
+	async function createFoo(db) {
+		const repo = new FooRepo(db);
 
-    async function createFoo(db) {
-        const repo = new FooRepo(db);
-
-        return await repo.create(new FooModel({
-            name: "name"
-        }, fixtures.user));
-    }
+		return await repo.create(new FooModel({
+			name: "name"
+		}, fixtures.user));
+	}
 });


### PR DESCRIPTION
Removes `afterEach(bus.clearClients);` from the test since it is done automatically by fruster test utils. 
**EDIT**: Looks like the whole test was reformatted, the bulk of the pr is this line https://github.com/FrostDigital/fruster-template-service-js/pull/15/files#diff-a1282820e646e9aa40bfe943f99265f3L23